### PR TITLE
Perf testing fixes

### DIFF
--- a/cmd/insert.go
+++ b/cmd/insert.go
@@ -117,6 +117,7 @@ func insertRun(cmd *cobra.Command, args []string) {
 		fmt.Println(throughput)
 	} else {
 		fmt.Println("Write Throughput:", throughput)
+		fmt.Println("Points Written:", totalWritten)
 	}
 }
 

--- a/stress/writer.go
+++ b/stress/writer.go
@@ -59,6 +59,10 @@ WRITE_BATCHES:
 			break WRITE_BATCHES
 		}
 
+		if pointCount >= cfg.MaxPoints {
+			break
+		}
+
 		for _, pt := range pts {
 			pointCount++
 			pt.SetTime(t)
@@ -81,12 +85,13 @@ WRITE_BATCHES:
 				if t.After(cfg.Deadline) {
 					break WRITE_BATCHES
 				}
+
+				if pointCount >= cfg.MaxPoints {
+					break
+				}
+
 			}
 			pt.Update()
-		}
-
-		if pointCount >= cfg.MaxPoints {
-			break WRITE_BATCHES
 		}
 	}
 

--- a/write/client.go
+++ b/write/client.go
@@ -80,6 +80,7 @@ func (c *client) Send(b []byte) (latNs int64, statusCode int, err error) {
 	if c.cfg.Gzip {
 		req.Header.SetBytesKV([]byte("Content-Encoding"), []byte("gzip"))
 	}
+	req.Header.SetContentLength(len(b))
 	req.SetBody(b)
 
 	resp := fasthttp.AcquireResponse()


### PR DESCRIPTION
Fix to set the content length which significantly improves throughput in some tests as well as fixing the number of points written.

cc @mark-rushakoff @desa 