### PR TITLE
Add strict mode and response body context

### DIFF
--- a/cmd/insert.go
+++ b/cmd/insert.go
@@ -24,6 +24,7 @@ var (
 	batchSize, pointsN, pps              uint64
 	runtime                              time.Duration
 	fast, quiet                          bool
+	strict                               bool
 )
 
 const (
@@ -149,6 +150,7 @@ func init() {
 	insertCmd.Flags().StringVar(&createCommand, "create", "", "Use a custom create database command")
 	insertCmd.Flags().IntVar(&gzip, "gzip", 0, "If non-zero, gzip write bodies with given compression level. 1=best speed, 9=best compression, -1=gzip default.")
 	insertCmd.Flags().StringVar(&dump, "dump", "", "Dump to given file instead of writing over HTTP")
+	insertCmd.Flags().BoolVarP(&strict, "strict", "", false, "Strict mode will exit as soon as an error or unexpected status is encountered")
 }
 
 func client() write.Client {
@@ -209,7 +211,7 @@ func (s *resultSink) printErrors() {
 		}
 
 		if r.StatusCode != 204 {
-			fmt.Fprintln(os.Stderr, time.Now().Format(timeFormat), "Unexpected write status:", r.StatusCode)
+			fmt.Fprintln(os.Stderr, time.Now().Format(timeFormat), "Unexpected write: status", r.StatusCode, ", body:", r.Body)
 		}
 	}
 }

--- a/stress/writer.go
+++ b/stress/writer.go
@@ -15,6 +15,7 @@ import (
 type WriteResult struct {
 	LatNs      int64
 	StatusCode int
+	Body       string // Only populated when unusual status code encountered.
 	Err        error
 }
 
@@ -106,10 +107,10 @@ WRITE_BATCHES:
 }
 
 func sendBatch(c write.Client, buf *bytes.Buffer, ch chan<- WriteResult) {
-	lat, status, err := c.Send(buf.Bytes())
+	lat, status, body, err := c.Send(buf.Bytes())
 	buf.Reset()
 	select {
-	case ch <- WriteResult{LatNs: lat, StatusCode: status, Err: err}:
+	case ch <- WriteResult{LatNs: lat, StatusCode: status, Body: body, Err: err}:
 	default:
 	}
 }


### PR DESCRIPTION
This PR adds _strict_ mode and response body context.

The latter simply means that when a non-204 status is returned, rather than just printing the status code, we'll also get the response body error message too. For example:

```
⇒  influx-stress insert --host http://localhost:8186 -c all --pps 10000 -n 10000
Using point template: ctr,some=tag n=0i <timestamp>
Using batch size of 10000 line(s)
Spreading writes across 100000 series
Throttling output to ~10000 points/sec
Using 1 concurrent writer(s)
Running until ~10000 points sent or until ~2562047h47m16.854775807s has elapsed
[2017-01-30 16:45:25] Unexpected write: status 500 , body: {"error":"partial write"}

Write Throughput: 9977
Points Written: 10000
```

Note the `body: {"error":"partial write"}`.

Strict mode adds a new flag to the `influx-stress` tool. Strict mode will terminate the process as soon as an error or a non-204 status code is received when writing to the server.

It's activated like this: `influx-stress insert -c all --pps 10000 -n 1000000 --strict`