### PR TITLE
[WIP] performance improvements for high cardinality

### DIFF
--- a/point/point.go
+++ b/point/point.go
@@ -1,6 +1,7 @@
 package point
 
 import (
+	"fmt"
 	"sync/atomic"
 	"time"
 
@@ -80,6 +81,107 @@ func (p *point) Update() {
 		// There will be a race here
 		f.Value += 1.0
 	}
+}
+
+// SeriesGenerator generates series to be written with influx-stress.
+type SeriesGenerator struct {
+	totalCardinality   int
+	currentCardinality int
+
+	template         string
+	tagCardinalities []int
+
+	batch []string
+	idx   int
+}
+
+func NewSeriesGenerator(tmplt string, cardinality int) *SeriesGenerator {
+	fmt.Printf("Generating %d cardinality\n", cardinality)
+	s := &SeriesGenerator{}
+	s.totalCardinality = cardinality
+	if cardinality < 100000 {
+		s.batch = make([]string, 0, cardinality)
+	} else {
+		s.batch = make([]string, 0, 100000)
+	}
+
+	var numTags int
+	s.template, numTags = formatTemplate(tmplt)
+	s.tagCardinalities = tagCardinalityPartition(numTags, primeFactorization(cardinality))
+	return s
+}
+
+// Next returns the next series to be generated.
+func (s *SeriesGenerator) Next() (string, bool) {
+	if s.currentCardinality == s.totalCardinality && s.idx == len(s.batch) {
+		// We have generated all series and written the last batch.
+		return "", false
+	}
+
+	if s.idx < len(s.batch) {
+		next := s.batch[s.idx]
+		s.idx++
+		return next, true
+	}
+
+	// Need to generate a new batch.
+	s.batch, s.idx = s.batch[:0], 1
+	for i := 0; i < cap(s.batch) && s.currentCardinality < s.totalCardinality; i++ {
+		s.batch = append(s.batch, fmt.Sprintf(s.template, sliceMod(s.currentCardinality, s.tagCardinalities)...))
+		s.currentCardinality++
+	}
+
+	// Return the first series in the batch.
+	if len(s.batch) == 0 {
+		return "", false
+	}
+	return s.batch[0], true
+}
+
+type PointGenerator struct {
+	SeriesGenerator *SeriesGenerator
+
+	// TODO(edd) make generator.
+	IntFields []string
+	// TODO(edd) make generator.
+	FloatFields []string
+
+	Precision lineprotocol.Precision
+	batch     []lineprotocol.Point
+}
+
+// NewPointGenerator creates a new generator for emitting points. Points are
+// created in batches of 20x the number of series created in a SeriesGenerator's
+// batch, up to a maximum batch of 500K points.
+func NewPointGenerator(seriesKey, fields string, seriesN int, pc lineprotocol.Precision) *PointGenerator {
+	p := PointGenerator{
+		SeriesGenerator: NewSeriesGenerator(seriesKey, seriesN),
+	}
+	p.IntFields, p.FloatFields = generateFieldSet(fields)
+
+	sz := cap(p.SeriesGenerator.batch) * 20
+	if sz > 500000 {
+		sz = 500000
+	}
+	p.batch = make([]lineprotocol.Point, 0, sz)
+
+	return &p
+}
+
+// Next returns a batch of points. A nil batch indicates there are no more
+// points in the generator.
+func (p *PointGenerator) Next() []lineprotocol.Point {
+	// Generate a new batch. Fill the batch with points from the series
+	// generator.
+	p.batch = p.batch[:0]
+	for i := 0; i < cap(p.batch); i++ {
+		series, ok := p.SeriesGenerator.Next()
+		if !ok {
+			break
+		}
+		p.batch = append(p.batch, New([]byte(series), p.IntFields, p.FloatFields, p.Precision))
+	}
+	return p.batch
 }
 
 // NewPoints returns a slice of Points of length seriesN shaped like the given seriesKey.

--- a/stress/writer.go
+++ b/stress/writer.go
@@ -37,7 +37,7 @@ type WriteConfig struct {
 // to write data to the target until one of the following conditions is met.
 // 1. We reach that MaxPoints specified in the WriteConfig.
 // 2. We've passed the Deadline specified in the WriteConfig.
-func Write(pts []lineprotocol.Point, c write.Client, cfg WriteConfig) (uint64, time.Duration) {
+func Write(pc <-chan []lineprotocol.Point, c write.Client, cfg WriteConfig) (uint64, time.Duration) {
 	if cfg.Results == nil {
 		panic("Results Channel on WriteConfig cannot be nil")
 	}
@@ -71,6 +71,8 @@ WRITE_BATCHES:
 			break
 		}
 
+		// Get next batch of points from the generator.
+		pts := <-pc
 		for _, pt := range pts {
 			pointCount++
 			pt.SetTime(t)


### PR DESCRIPTION
`influx-stress` currently pre-allocates all series and points when starting up, which makes running high cardinality loads nigh on impossible locally.

The PR helps somewhat with this problem by only generating batches of the series and points we need as and when needed.

Series are generated in batches of 100,000, while line-protocol points are generated in batches of 500,000.

We may want to tweak these numbers; I haven't tested. However previously, writing 100M series ate up over 18GB of RAM, while doing it this way seems to consume a few hundred.

I'm not sure if it's impacted the maximum throughput significantly yet however.