### PR TITLE
Use pps as the source of truth

### DIFF
--- a/cmd/insert.go
+++ b/cmd/insert.go
@@ -56,6 +56,12 @@ func insertRun(cmd *cobra.Command, args []string) {
 	}
 
 	concurrency := pps / batchSize
+	// PPS takes precedence over batchSize.
+	// Adjust accordingly.
+	if pps < batchSize {
+		batchSize = pps
+		concurrency = 1
+	}
 	if !quiet {
 		fmt.Printf("Using point template: %s %s <timestamp>\n", seriesKey, fieldStr)
 		fmt.Printf("Using batch size of %d line(s)\n", batchSize)


### PR DESCRIPTION
I set a pps of 1 to just test I was getting the correct data output and I got a panic. Looking at the code, any time pps < batchSize a panic would occur. 

Since this is not a good user experience, either pps needs to be recomputed or batchSize does. I decided that making pps the source of truth for what the user wants makes the most sense, because batch size is about how the data is transferred not how much data is transferred. 

This change makes it so that if pps < batchSize the batchSize it changed to be equal to pps and concurrency is set to 1.

